### PR TITLE
change snmp

### DIFF
--- a/snmp.go
+++ b/snmp.go
@@ -2,6 +2,7 @@ package kcp
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 )
 
@@ -148,6 +149,9 @@ func (s *Snmp) Reset() {
 
 // DefaultSnmp is the global KCP connection statistics collector
 var DefaultSnmp *Snmp
+
+// Snmps store the map of hostname to snmp
+var Snmps sync.Map
 
 func init() {
 	DefaultSnmp = newSnmp()

--- a/snmp.go
+++ b/snmp.go
@@ -163,11 +163,14 @@ func getSnmp(remotes []string) *Snmp {
 	Snmps.RUnlock()
 	if snmp == nil {
 		Snmps.Lock()
-		snmp = newSnmp()
-		// store snmp into addr map
-		for _, addr := range remotes {
-			IP := addr[:strings.Index(addr, ":")]
-			Snmps.sMap[IP] = snmp
+		IP := remotes[0][:strings.Index(remotes[0], ":")]
+		if _, ok := Snmps.sMap[IP]; !ok {
+			snmp = newSnmp()
+			// store snmp into addr map
+			for _, addr := range remotes {
+				IP := addr[:strings.Index(addr, ":")]
+				Snmps.sMap[IP] = snmp
+			}
 		}
 		Snmps.Unlock()
 	}
@@ -189,7 +192,5 @@ var Snmps *SnmpMap
 func init() {
 	DefaultSnmp = newSnmp()
 	Snmps = new(SnmpMap)
-	Snmps.Lock()
 	Snmps.sMap = make(map[string]*Snmp)
-	Snmps.Unlock()
 }

--- a/stream.go
+++ b/stream.go
@@ -158,24 +158,7 @@ func NewUDPStream(uuid gouuid.UUID, accepted bool, remotes []string, pc *paralle
 	stream.pc = pc
 	stream.ackNoDelayRatio = DefaultAckNoDelayRatio
 	stream.ackNoDelayCount = DefaultAckNoDelayCount
-	var snmp *Snmp
-	for _, addr := range remotes {
-		// KEY: since remotes must act like "127.0.0.1:8000", we ignore the validation
-		// TODO: if we use IPV6, we need change there
-		IP := addr[:strings.Index(addr, ":")]
-		if snmpInf, ok := Snmps.Load(IP); ok {
-			snmp = snmpInf.(*Snmp)
-			break
-		}
-	}
-	if snmp == nil {
-		snmp = newSnmp()
-		// store snmp into addr map
-		for _, addr := range remotes {
-			IP := addr[:strings.Index(addr, ":")]
-			Snmps.Store(IP, snmp)
-		}
-	}
+	snmp := getSnmp(remotes)
 	stream.kcp = NewKCP(1, snmp, func(buf []byte, size int, xmitMax uint32) {
 		if size >= IKCP_OVERHEAD+stream.headerSize {
 			stream.output(buf[:size], xmitMax)


### PR DESCRIPTION
Change default snmp to specific snmp to collect statistic points from kcp state machine. Snmps is a sync.Map to store IP->snmp map, cooperating with authproxy3 IP2HostMap.
